### PR TITLE
Force the use of a format to parse a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - `Innmind\TimeContinuum\PointInTime::timezone()` has been renamed `Innmind\TimeContinuum\PointInTime::offset()`
 - `Innmind\TimeContinuum\PointInTime\Day::toInt()` has been renamed `Innmind\TimeContinuum\PointInTime\Day::ofMonth()`
 - `Innmind\TimeContinuum\ElapsedPeriod::of()` is now an `internal` method
+- `Innmind\TimeContinuum\Clock::at()` now requires a `Format`
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ composer install innmind/time-continuum
 use Innmind\TimeContinuum\{
     Clock,
     PointInTime,
+    Format,
 };
 use Innmind\Immutable\Maybe;
 
@@ -27,7 +28,10 @@ $clock = Clock::live();
 $now = $clock->now(); // return an instance of PointInTime
 echo $now->toString(); // 2016-10-11T12:17:30+02:00
 
-$epoch = $clock->at('1970-01-01T00:00:00.000000Z'); // Maybe<PointInTime>
+$epoch = $clock->at(
+    '1970-01-01T00:00:00.000000+00:00',
+    Format::iso8601(),
+); // Maybe<PointInTime>
 ```
 
 Here we reference 2 points in time, the first is the exact moment we call `now` down to the millisecond and the second one is the epoch time (you can verify it via `$epoch->milliseconds()` that returns `0`).

--- a/proofs/clock.php
+++ b/proofs/clock.php
@@ -98,7 +98,6 @@ return static function() {
         given(
             Set\Unicode::strings(),
             Set\Elements::of(
-                null,
                 Format::cookie(),
                 Format::iso8601(),
                 Format::rfc1036(),

--- a/src/Clock.php
+++ b/src/Clock.php
@@ -53,7 +53,7 @@ final class Clock
      *
      * @return Maybe<PointInTime>
      */
-    public function at(string $date, Format $format = null): Maybe
+    public function at(string $date, Format $format): Maybe
     {
         /**
          * @psalm-suppress ImpureVariable

--- a/src/Clock/Frozen.php
+++ b/src/Clock/Frozen.php
@@ -48,7 +48,7 @@ final class Frozen
      *
      * @return Maybe<PointInTime>
      */
-    public function at(string $date, Format $format = null): Maybe
+    public function at(string $date, Format $format): Maybe
     {
         /**
          * @psalm-suppress ImpureVariable

--- a/src/Clock/Live.php
+++ b/src/Clock/Live.php
@@ -57,36 +57,24 @@ final class Live
      *
      * @return Maybe<PointInTime>
      */
-    public function at(string $date, Format $format = null): Maybe
+    public function at(string $date, Format $format): Maybe
     {
-        if ($format instanceof Format) {
-            try {
-                /** @psalm-suppress ImpureMethodCall */
-                $datetime = \DateTimeImmutable::createFromFormat($format->toString(), $date);
-            } catch (\Throwable) {
-                /** @var Maybe<PointInTime> */
-                return Maybe::nothing();
-            }
+        try {
+            /** @psalm-suppress ImpureMethodCall */
+            $datetime = \DateTimeImmutable::createFromFormat($format->toString(), $date);
+        } catch (\Throwable) {
+            /** @var Maybe<PointInTime> */
+            return Maybe::nothing();
+        }
 
-            if ($datetime === false) {
-                /** @var Maybe<PointInTime> */
-                return Maybe::nothing();
-            }
+        if ($datetime === false) {
+            /** @var Maybe<PointInTime> */
+            return Maybe::nothing();
+        }
 
-            if ($datetime->format($format->toString()) !== $date) {
-                /** @var Maybe<PointInTime> */
-                return Maybe::nothing();
-            }
-
-            $date = $datetime->format(\DateTime::ATOM);
-        } else {
-            try {
-                /** @psalm-suppress ImpureMethodCall */
-                $datetime = new \DateTimeImmutable($date);
-            } catch (\Throwable) {
-                /** @var Maybe<PointInTime> */
-                return Maybe::nothing();
-            }
+        if ($datetime->format($format->toString()) !== $date) {
+            /** @var Maybe<PointInTime> */
+            return Maybe::nothing();
         }
 
         /**

--- a/src/Clock/Logger.php
+++ b/src/Clock/Logger.php
@@ -55,7 +55,7 @@ final class Logger
      *
      * @return Maybe<PointInTime>
      */
-    public function at(string $date, Format $format = null): Maybe
+    public function at(string $date, Format $format): Maybe
     {
         /**
          * @psalm-suppress ImpureVariable
@@ -67,22 +67,10 @@ final class Logger
             ->map(fn($point) => $this->log($point, $date, $format));
     }
 
-    /**
-     * @psalm-pure
-     */
-    private function format(?Format $format): string
-    {
-        if (\is_null($format)) {
-            return 'unknown';
-        }
-
-        return $format->toString();
-    }
-
     private function log(
         PointInTime $point,
         string $date,
-        ?Format $format,
+        Format $format,
     ): PointInTime {
         /**
          * @psalm-suppress ImpureVariable
@@ -91,7 +79,7 @@ final class Logger
          */
         $this->logger->debug('Asked time {date} ({format}) resolved to {point}', [
             'date' => $date,
-            'format' => $this->format($format),
+            'format' => $format->toString(),
             'point' => $point->format(Format::iso8601()),
         ]);
 

--- a/tests/Clock/FrozenTest.php
+++ b/tests/Clock/FrozenTest.php
@@ -37,7 +37,7 @@ class FrozenTest extends TestCase
             ->then(function($now, $at) {
                 $clock = Clock::frozen($now);
 
-                $point = $clock->at($at->format(Format::iso8601()))->match(
+                $point = $clock->at($at->format(Format::iso8601()), Format::iso8601())->match(
                     static fn($point) => $point,
                     static fn() => null,
                 );

--- a/tests/Clock/LiveTest.php
+++ b/tests/Clock/LiveTest.php
@@ -37,7 +37,7 @@ class LiveTest extends TestCase
     {
         $this->assertInstanceOf(
             PointInTime::class,
-            $point = Clock::live()->at('2016-10-08T16:08:30+02:00')->match(
+            $point = Clock::live()->at('2016-10-08T16:08:30+02:00', Format::iso8601())->match(
                 static fn($point) => $point,
                 static fn() => null,
             ),

--- a/tests/Clock/LoggerTest.php
+++ b/tests/Clock/LoggerTest.php
@@ -77,7 +77,7 @@ class LoggerTest extends TestCase
 
                 $this->assertSame(
                     $point->toString(),
-                    $clock->at($point->toString())->match(
+                    $clock->at($point->format(Format::iso8601()), Format::iso8601())->match(
                         static fn($found) => $found->toString(),
                         static fn() => null,
                     ),
@@ -88,8 +88,8 @@ class LoggerTest extends TestCase
                         'debug',
                         'Asked time {date} ({format}) resolved to {point}',
                         [
-                            'date' => $point->toString(),
-                            'format' => 'unknown',
+                            'date' => $point->format(Format::iso8601()),
+                            'format' => Format::iso8601()->toString(),
                             'point' => $point->format(Format::iso8601()),
                         ],
                     ],

--- a/tests/ClockTest.php
+++ b/tests/ClockTest.php
@@ -107,7 +107,7 @@ class ClockTest extends TestCase
                 );
                 $this->assertSame(
                     $frozen->now()->toString(),
-                    $clock->at($point->toString())->match(
+                    $clock->at($point->format(Format::iso8601()), Format::iso8601())->match(
                         static fn($point) => $point->toString(),
                         static fn() => null,
                     ),


### PR DESCRIPTION
This is intended to avoid implicit behaviours.