### PR TITLE
Fix `PointInTime::equals()` and `::aheadOf()`

### DIFF
--- a/proofs/clock.php
+++ b/proofs/clock.php
@@ -141,4 +141,33 @@ return static function() {
             );
         },
     );
+
+    yield proof(
+        'Each call to Clock::now() is ahead of the previous',
+        given(Set\Nullable::of(Set\Integers::between(1, 2_000_000))), // up to 2 seconds
+        static function($assert, $microsecond) {
+            $clock = Clock::live();
+            $start = $clock->now();
+
+            if (\is_int($microsecond)) {
+                \usleep($microsecond);
+            }
+
+            $assert->true(
+                $clock->now()->aheadOf(
+                    $start,
+                ),
+            );
+        },
+    );
+
+    yield test(
+        'Clock::now() is equal to iteself',
+        static function($assert) {
+            $clock = Clock::live();
+            $now = $clock->now();
+
+            $assert->true($now->equals($now));
+        },
+    );
 };

--- a/proofs/pointInTime.php
+++ b/proofs/pointInTime.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types = 1);
+
+use Innmind\TimeContinuum\Period;
+use Fixtures\Innmind\TimeContinuum as Fixtures;
+use Innmind\BlackBox\Set;
+
+return static function() {
+    yield proof(
+        'PointInTime::equals()',
+        given(
+            Fixtures\PointInTime::any(),
+            Set\Either::any(
+                Set\Integers::above(0)->map(Period::microsecond(...)),
+                Set\Integers::above(0)->map(Period::millisecond(...)),
+            ),
+        ),
+        static function($assert, $point, $period) {
+            $assert->true(
+                $point
+                    ->goForward($period)
+                    ->goBack($period)
+                    ->equals($point),
+            );
+            $assert->true(
+                $point
+                    ->goBack($period)
+                    ->goForward($period)
+                    ->equals($point),
+            );
+            $assert->false(
+                $point
+                    ->goBack($period)
+                    ->equals($point),
+            );
+            $assert->false(
+                $point
+                    ->goForward($period)
+                    ->equals($point),
+            );
+        },
+    );
+
+    yield proof(
+        'PointInTime::aheadOf()',
+        given(
+            Fixtures\PointInTime::any(),
+            Fixtures\Period::any()->filter(
+                static fn($period) => !$period->equals(Period::microsecond(0)),
+            ),
+        ),
+        static function($assert, $point, $period) {
+            $assert->true(
+                $point
+                    ->goForward($period)
+                    ->aheadOf($point),
+            );
+            $assert->false(
+                $point
+                    ->goBack($period)
+                    ->aheadOf($point),
+            );
+        },
+    );
+};

--- a/src/PointInTime.php
+++ b/src/PointInTime.php
@@ -213,35 +213,25 @@ final class PointInTime
 
     public function equals(self $point): bool
     {
-        [$self, $other] = self::compare($this, $point);
+        $format = Format::of('Y-m-dTH:i:s.u');
+        $self = $this->changeOffset(Offset::utc())->format($format);
+        $other = $point->changeOffset(Offset::utc())->format($format);
 
         return $self === $other;
     }
 
     public function aheadOf(self $point): bool
     {
-        [$self, $other] = self::compare($this, $point);
+        if (!\is_null($this->highResolution) && !\is_null($point->highResolution)) {
+            return $this->highResolution->aheadOf($point->highResolution);
+        }
 
-        return $self > $other;
+        return $this->date > $point->date;
     }
 
     public function toString(): string
     {
         return $this->date->format('Y-m-d\TH:i:s.uP');
-    }
-
-    /**
-     * @psalm-pure
-     * @return array{string, string}
-     */
-    private static function compare(self $self, self $other): array
-    {
-        $format = Format::of('Y-m-dTH:i:s.u');
-
-        return [
-            $self->changeOffset(Offset::utc())->format($format),
-            $other->changeOffset(Offset::utc())->format($format),
-        ];
     }
 
     /**

--- a/src/PointInTime/HighResolution.php
+++ b/src/PointInTime/HighResolution.php
@@ -46,6 +46,15 @@ final class HighResolution
         return new self($seconds, $nanoseconds);
     }
 
+    public function aheadOf(self $other): bool
+    {
+        if ($this->seconds > $other->seconds) {
+            return true;
+        }
+
+        return $this->nanoseconds > $other->nanoseconds;
+    }
+
     public function elapsedSince(self $other): ElapsedPeriod
     {
         $seconds = $this->seconds - $other->seconds;


### PR DESCRIPTION
By adding proofs on these 2 methods it revealed it wasn't behaving correctly for all points in time.

It also showed that `::aheadOf()` should also handle high resolution time.