### PR TITLE
Add PHP 8.4 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,70 +3,12 @@ name: CI
 on: [push]
 
 jobs:
-  phpunit:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macOS-latest]
-        php-version: ['8.2', '8.3']
-        dependencies: ['lowest', 'highest']
-    name: 'BlackBox'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-version }}
-          extensions: mbstring, intl
-          coverage: xdebug
-      - name: Composer
-        uses: "ramsey/composer-install@v3"
-        with:
-          dependency-versions: ${{ matrix.dependencies }}
-      - name: BlackBox
-        run: php blackbox.php
-        env:
-          ENABLE_COVERAGE: 'true'
-      - uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+  coverage:
+    uses: innmind/github-workflows/.github/workflows/coverage-matrix.yml@main
+    secrets: inherit
   psalm:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php-version: ['8.2', '8.3']
-        dependencies: ['lowest', 'highest']
-    name: 'Psalm'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-version }}
-          extensions: mbstring, intl
-      - name: Composer
-        uses: "ramsey/composer-install@v3"
-        with:
-          dependency-versions: ${{ matrix.dependencies }}
-      - name: Psalm
-        run: vendor/bin/psalm --shepherd
+    uses: innmind/github-workflows/.github/workflows/psalm-matrix.yml@main
   cs:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php-version: ['8.2']
-    name: 'CS'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-version }}
-          extensions: mbstring, intl
-      - name: Composer
-        uses: "ramsey/composer-install@v3"
-      - name: CS
-        run: vendor/bin/php-cs-fixer fix --diff --dry-run
+    uses: innmind/github-workflows/.github/workflows/cs.yml@main
+    with:
+      php-version: '8.2'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,27 +1,10 @@
 name: Documentation
 on:
   push:
-    branches: [master]
+    branches: [master, main]
 permissions:
   contents: write
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Configure Git Credentials
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
-      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - uses: actions/cache@v4
-        with:
-          key: mkdocs-material-${{ env.cache_id }}
-          path: .cache
-          restore-keys: |
-            mkdocs-material-
-      - run: pip install mkdocs-material
-      - run: mkdocs gh-deploy --force
+    uses: innmind/github-workflows/.github/workflows/documentation.yml@main
+    secrets: inherit

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -9,25 +9,9 @@ on:
 
 jobs:
   blackbox:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        php-version: ['8.3']
-        dependency-versions: ['highest']
-    name: 'BlackBox'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-version }}
-          extensions: mbstring, intl
-          coverage: none
-      - name: Composer
-        uses: "ramsey/composer-install@v3"
-        with:
-          dependency-versions: ${{ matrix.dependencies }}
-      - name: BlackBox
-        run: php blackbox.php ci
+    uses: innmind/github-workflows/.github/workflows/coverage.yml@main
+    secrets: inherit
+    with:
+      tags: ci
+      os: ubuntu-latest
+      php-version: '8.3'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,19 +5,7 @@ on:
     tags:
       - '*'
 
-permissions:
-  contents: write
-
 jobs:
   release:
-    name: Create release
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Create release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ github.ref_name }}
-        run: |
-          gh release create "$tag" \
-              --repo="$GITHUB_REPOSITORY" \
-              --generate-notes
+    uses: innmind/github-workflows/.github/workflows/release.yml@main
+    secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Support for PHP `8.4`
+- An error were `Innmind\TimeContinuum\MoveEndOfMonth` would change the month on leap years
 
 ## 4.0.0 - 2024-11-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Support for PHP `8.4`
+
 ## 4.0.0 - 2024-11-28
 
 ## Added

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         }
     },
     "require-dev": {
-        "vimeo/psalm": "~5.13",
+        "vimeo/psalm": "~5.13|dev-master",
         "innmind/black-box": "~5.8",
         "innmind/coding-standard": "^2.0.1"
     },

--- a/proofs/move/endOfMonth.php
+++ b/proofs/move/endOfMonth.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 use Innmind\TimeContinuum\{
     Clock,
     Move\EndOfMonth,
+    Format,
 };
 use Fixtures\Innmind\TimeContinuum\PointInTime;
 use Innmind\BlackBox\Set;
@@ -16,6 +17,58 @@ return static function() {
             Set\Call::of(static fn() => Clock::live()->now()),
         )),
         static function($assert, $point) {
+            $endOfMonth = (new EndOfMonth)($point);
+
+            $assert->same(
+                $point->year()->toInt(),
+                $endOfMonth->year()->toInt(),
+            );
+            $assert->same(
+                $point->month()->ofYear(),
+                $endOfMonth->month()->ofYear(),
+            );
+            $assert->same(
+                $point->month()->numberOfDays(),
+                $endOfMonth->day()->ofMonth(),
+            );
+            $assert->same(
+                23,
+                $endOfMonth->hour()->toInt(),
+            );
+            $assert->same(
+                59,
+                $endOfMonth->minute()->toInt(),
+            );
+            $assert->same(
+                59,
+                $endOfMonth->second()->toInt(),
+            );
+            $assert->same(
+                999,
+                $endOfMonth->millisecond()->toInt(),
+            );
+            $assert->same(
+                999,
+                $endOfMonth->microsecond()->toInt(),
+            );
+        },
+    );
+
+    yield test(
+        'End of month regression',
+        static function($assert) {
+            $point = Clock::live()
+                ->at(
+                    '0100-02-27T18:35:40.134853+01:00',
+                    Format::of('Y-m-d\TH:i:s.uP'),
+                )
+                ->match(
+                    static fn($point) => $point,
+                    static fn() => null,
+                );
+
+            $assert->object($point);
+
             $endOfMonth = (new EndOfMonth)($point);
 
             $assert->same(

--- a/src/PointInTime.php
+++ b/src/PointInTime.php
@@ -303,6 +303,6 @@ final class PointInTime
         }
 
         /** @psalm-suppress ImpureMethodCall */
-        return \DateInterval::createFromDateString(\implode(' + ', $parts));
+        return \DateInterval::createFromDateString(\implode(' + ', $parts)) ?: null;
     }
 }

--- a/src/PointInTime.php
+++ b/src/PointInTime.php
@@ -59,22 +59,12 @@ final class PointInTime
 
     public function month(): Month
     {
-        return Month::of(
-            $this->year(),
-            Calendar\Month::of((int) $this->date->format('n')),
-        );
+        return Month::of($this->date);
     }
 
     public function day(): Day
     {
-        /** @var int<1, 31> */
-        $day = (int) $this->date->format('j');
-
-        return Day::of(
-            $this->year(),
-            $this->month(),
-            $day,
-        );
+        return Day::of($this->date);
     }
 
     public function hour(): Hour

--- a/src/PointInTime/Day.php
+++ b/src/PointInTime/Day.php
@@ -16,29 +16,24 @@ final class Day
     /** @var int<0, 365> */
     private int $ofYear;
 
-    /**
-     * @param int<1, 31> $day
-     */
-    private function __construct(Year $year, Month $month, int $day)
+    private function __construct(\DateTimeImmutable $date)
     {
+        /** @var int<1, 31> */
+        $day = (int) $date->format('j');
+
         $this->day = $day;
-        $this->week = Calendar\Day::of((int) \date(
-            'w',
-            $time = \mktime(0, 0, 0, $month->ofYear()->toInt(), $day, $year->toInt()),
-        ));
+        $this->week = Calendar\Day::of((int) $date->format('w'));
         /** @var int<0, 365> */
-        $this->ofYear = (int) \date('z', $time);
+        $this->ofYear = (int) $date->format('z');
     }
 
     /**
      * @psalm-pure
      * @internal
-     *
-     * @param int<1, 31> $day
      */
-    public static function of(Year $year, Month $month, int $day): self
+    public static function of(\DateTimeImmutable $date): self
     {
-        return new self($year, $month, $day);
+        return new self($date);
     }
 
     public function ofWeek(): Calendar\Day

--- a/src/PointInTime/Month.php
+++ b/src/PointInTime/Month.php
@@ -14,23 +14,20 @@ final class Month
     /** @var int<28, 31> */
     private int $days;
 
-    private function __construct(Year $year, Calendar\Month $month)
+    private function __construct(\DateTimeImmutable $date)
     {
-        $this->month = $month;
+        $this->month = Calendar\Month::of((int) $date->format('n'));
         /** @var int<28, 31> */
-        $this->days = (int) \date(
-            't',
-            \mktime(0, 0, 0, $month->toInt(), 1, $year->toInt()),
-        );
+        $this->days = (int) $date->format('t');
     }
 
     /**
      * @psalm-pure
      * @internal
      */
-    public static function of(Year $year, Calendar\Month $month): self
+    public static function of(\DateTimeImmutable $date): self
     {
-        return new self($year, $month);
+        return new self($date);
     }
 
     /**

--- a/src/PointInTime/Year.php
+++ b/src/PointInTime/Year.php
@@ -16,7 +16,7 @@ final class Year
     {
         $this->year = $year;
         /** @var 365|366 */
-        $this->days = (int) \date('z', \mktime(0, 0, 0, 12, 31, $year)) + 1;
+        $this->days = ((int) (new \DateTimeImmutable("{$year}-12-31T00:00:00"))->format('z')) + 1;
     }
 
     /**

--- a/tests/NowTest.php
+++ b/tests/NowTest.php
@@ -110,11 +110,11 @@ class NowTest extends TestCase
 
         $this->assertTrue(
             $point2->aheadOf($point),
-            $point->format(Format::iso8601()).' '.$point2->format(Format::iso8601()),
+            $point->format(Format::of('Y-m-d\TH:i:s.uP')).' '.$point2->format(Format::of('Y-m-d\TH:i:s.uP')),
         );
         $this->assertFalse(
             $point->aheadOf($point2),
-            $point->format(Format::iso8601()).' '.$point2->format(Format::iso8601()),
+            $point->format(Format::of('Y-m-d\TH:i:s.uP')).' '.$point2->format(Format::of('Y-m-d\TH:i:s.uP')),
         );
     }
 

--- a/tests/NowTest.php
+++ b/tests/NowTest.php
@@ -108,8 +108,14 @@ class NowTest extends TestCase
         \sleep(1);
         $point2 = PointInTime::now();
 
-        $this->assertTrue($point2->aheadOf($point));
-        $this->assertFalse($point->aheadOf($point2));
+        $this->assertTrue(
+            $point2->aheadOf($point),
+            $point->format(Format::iso8601()).' '.$point2->format(Format::iso8601()),
+        );
+        $this->assertFalse(
+            $point->aheadOf($point2),
+            $point->format(Format::iso8601()).' '.$point2->format(Format::iso8601()),
+        );
     }
 
     public function testEquals()

--- a/tests/PointInTime/DayTest.php
+++ b/tests/PointInTime/DayTest.php
@@ -3,26 +3,14 @@ declare(strict_types = 1);
 
 namespace Tests\Innmind\TimeContinuum\PointInTime;
 
-use Innmind\TimeContinuum\{
-    PointInTime\Day,
-    PointInTime\Month,
-    PointInTime\Year,
-    Calendar,
-};
+use Innmind\TimeContinuum\PointInTime\Day;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
 
 class DayTest extends TestCase
 {
     public function testInterface()
     {
-        $day = Day::of(
-            $year = Year::of(2016),
-            Month::of(
-                $year,
-                Calendar\Month::of(10),
-            ),
-            5,
-        );
+        $day = Day::of(new \DateTimeImmutable('2016-10-05T00:00:00'));
 
         $this->assertSame(3, $day->ofWeek()->toInt());
         $this->assertSame(278, $day->ofYear());

--- a/tests/PointInTime/MonthTest.php
+++ b/tests/PointInTime/MonthTest.php
@@ -3,18 +3,14 @@ declare(strict_types = 1);
 
 namespace Tests\Innmind\TimeContinuum\PointInTime;
 
-use Innmind\TimeContinuum\{
-    PointInTime\Month,
-    PointInTime\Year,
-    Calendar,
-};
+use Innmind\TimeContinuum\PointInTime\Month;
 use Innmind\BlackBox\PHPUnit\Framework\TestCase;
 
 class MonthTest extends TestCase
 {
     public function testInterface()
     {
-        $month = Month::of(Year::of(2016), Calendar\Month::of(10));
+        $month = Month::of(new \DateTimeImmutable('2016-10-01T00:00:00'));
 
         $this->assertSame(31, $month->numberOfDays());
         $this->assertSame(10, $month->ofYear()->toInt());


### PR DESCRIPTION
While running blackbox for the PHP 8.4 support it found a bug where `mktime` produced errors since the values below `101` for the year represent the dates between 1970 and 2069.

Hence the big diff on `Day` and `Month`.