### PR TITLE
Fix comparing 2 high resolution points in time when more than a second has elapsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- When comparing 2 high resolution points in time, if the elapsed time between the 2 is higher than a second it could return that the start point is ahead of the end one.
+
 ## 4.0.1 - 2025-01-19
 
 ### Fixed

--- a/proofs/pointInTime/highResolution.php
+++ b/proofs/pointInTime/highResolution.php
@@ -20,7 +20,7 @@ return static function() {
             $assert->true($end->aheadOf($start));
             $assert->false($start->aheadOf($end));
         },
-    )->tag(\Innmind\BlackBox\Tag::wip);
+    );
 
     yield proof(
         'HighResolution::aheadOf() in same second',
@@ -36,5 +36,5 @@ return static function() {
             $assert->true($end->aheadOf($start));
             $assert->false($start->aheadOf($end));
         },
-    )->tag(\Innmind\BlackBox\Tag::wip);
+    );
 };

--- a/proofs/pointInTime/highResolution.php
+++ b/proofs/pointInTime/highResolution.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types = 1);
+
+use Innmind\TimeContinuum\PointInTime\HighResolution;
+use Innmind\BlackBox\Set;
+
+return static function() {
+    yield proof(
+        'HighResolution::aheadOf() on different seconds',
+        given(
+            Set\Integers::above(0),
+            Set\Integers::above(0),
+            Set\Integers::between(0, 999_999_999),
+            Set\Integers::between(0, 999_999_999),
+        )->filter(static fn($start, $end) => $start < $end),
+        static function($assert, $start, $end, $startNanoseconds, $endNanoseconds) {
+            $start = HighResolution::of($start, $startNanoseconds);
+            $end = HighResolution::of($end, $endNanoseconds);
+
+            $assert->true($end->aheadOf($start));
+            $assert->false($start->aheadOf($end));
+        },
+    )->tag(\Innmind\BlackBox\Tag::wip);
+
+    yield proof(
+        'HighResolution::aheadOf() in same second',
+        given(
+            Set\Integers::above(0),
+            Set\Integers::between(0, 999_999_999),
+            Set\Integers::between(0, 999_999_999),
+        )->filter(static fn($_, $start, $end) => $start < $end),
+        static function($assert, $second, $start, $end) {
+            $start = HighResolution::of($second, $start);
+            $end = HighResolution::of($second, $end);
+
+            $assert->true($end->aheadOf($start));
+            $assert->false($start->aheadOf($end));
+        },
+    )->tag(\Innmind\BlackBox\Tag::wip);
+};

--- a/src/PointInTime/HighResolution.php
+++ b/src/PointInTime/HighResolution.php
@@ -52,6 +52,10 @@ final class HighResolution
             return true;
         }
 
+        if ($this->seconds < $other->seconds) {
+            return false;
+        }
+
         return $this->nanoseconds > $other->nanoseconds;
     }
 


### PR DESCRIPTION
## Problem

A condition is missing when comparing if a `HighResolution` is ahead of an other. If the start point second is below the other one then it will return it's ahead if the number of nanoseconds is higher.

## Fix

If the start second is below the other always return false as there is no need to check the nanoseconds.